### PR TITLE
Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.3
 RUN apk --update add \
     coreutils \
     py-pip \
+    python \
     && pip install https://github.com/pebble/cloudwatch-mon-scripts-python/tarball/master\#egg\=cloudwatchmon-2.0.3 \
     && apk del py-pip \
     && rm -rf /var/cache/apk/* 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM alpine:3.3
 RUN apk --update add \
     coreutils \
     py-pip \
-    python \
     && pip install https://github.com/pebble/cloudwatch-mon-scripts-python/tarball/master\#egg\=cloudwatchmon-2.0.3 \
-    && apk del py-pip \
     && rm -rf /var/cache/apk/* 
 
 CMD sed '1d' -i /etc/mtab && /usr/bin/mon-put-instance-stats.py \


### PR DESCRIPTION
Reverting my earlier change, removed python (which is required for the py script) and it requires pip libraries.

@pebble/webops (fyi, all docker-cloudwatch are broken now, so merging to fix)
