### PR TITLE
WEBOPS-889: use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ RUN apk --update add \
     git \
     && pip install git+https://github.com/pebble/cloudwatch-mon-scripts-python.git@master
 
-CMD sed '1d' -i /etc/mtab && /usr/bin/mon-put-instance-stats.py \
-    --mem-util \
-    --disk-space-util \
-    --disk-path=/ \
-    --auto-scaling \
-    --auto-scaling-group=$ASG \
-    --persistent
+COPY stats.sh /stats.sh
+
+ENTRYPOINT ["/stats.sh"]

--- a/stats.sh
+++ b/stats.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+sed '1d' -i /etc/mtab && /usr/bin/mon-put-instance-stats.py \
+    --mem-util \
+    --disk-space-util \
+    --disk-path=/ \
+    --auto-scaling \
+    --auto-scaling-group=$ASG \
+    --persistent $*


### PR DESCRIPTION
This makes it easier to pass additional arguments to the container.

Sample usage:
`docker run -v /mnt/foo:/mnt/foo pebbletech/cloudwatch-stats --disk-path/mnt/foo`
